### PR TITLE
feat(analytics): расширенные ER-метрики, PNG-графики и smoke-тесты

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,8 @@ sentry-sdk==2.3.1
 # Production server
 uvicorn[standard]==0.29.0
 fastapi==0.111.0
+
+# Testing
+pytest==8.2.2
+pytest-asyncio==0.23.7
+pytest-cov==5.0.0

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -105,6 +105,17 @@ class DatabaseService:
             stmt = select(Channel).where(Channel.channel_id == channel_id)
             result = await session.execute(stmt)
             return result.scalar_one_or_none()
+
+    async def get_channel_by_username(self, username: str) -> Optional[Channel]:
+        """Получение канала по username (без @, регистронезависимо)."""
+        normalized_username = username.lstrip('@').strip().lower()
+        if not normalized_username:
+            return None
+
+        async with self.get_session() as session:
+            stmt = select(Channel).where(func.lower(Channel.username) == normalized_username)
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
     
     async def get_active_channels(self) -> List[Channel]:
         """Получение всех активных каналов"""
@@ -269,6 +280,17 @@ class DatabaseService:
             ).order_by(ViewDaily.date)
             views_result = await session.execute(views_stmt)
             views_history = views_result.scalars().all()
+
+            # Все посты в периоде для детальной аналитики
+            period_start_dt = datetime.combine(start_date, datetime.min.time())
+            period_posts_stmt = select(Post).where(
+                and_(
+                    Post.channel_id == channel_id,
+                    Post.posted_at >= period_start_dt
+                )
+            ).order_by(desc(Post.posted_at))
+            period_posts_result = await session.execute(period_posts_stmt)
+            period_posts = period_posts_result.scalars().all()
             
             # Последние посты
             posts_stmt = select(Post).where(
@@ -276,7 +298,172 @@ class DatabaseService:
             ).order_by(desc(Post.posted_at)).limit(10)
             posts_result = await session.execute(posts_stmt)
             recent_posts = posts_result.scalars().all()
-            
+
+            # Периодные агрегаты подписчиков
+            members_total_growth = 0
+            members_growth_percent = 0.0
+            avg_daily_growth = 0.0
+            growth_days = 0
+            decline_days = 0
+            stable_days = 0
+
+            if members_history:
+                first_members = members_history[0].members_count
+                last_members = members_history[-1].members_count
+                members_total_growth = last_members - first_members
+                if first_members > 0:
+                    members_growth_percent = (members_total_growth / first_members) * 100
+
+                members_growth_values = [int(item.members_growth or 0) for item in members_history]
+                if members_growth_values:
+                    avg_daily_growth = sum(members_growth_values) / len(members_growth_values)
+                    growth_days = sum(1 for value in members_growth_values if value > 0)
+                    decline_days = sum(1 for value in members_growth_values if value < 0)
+                    stable_days = len(members_growth_values) - growth_days - decline_days
+
+            # Периодные агрегаты просмотров и вовлеченности
+            total_views_period = sum(int(item.total_views or 0) for item in views_history)
+            total_posts_period = sum(int(item.posts_count or 0) for item in views_history)
+            total_reactions_period = sum(int(item.total_reactions or 0) for item in views_history)
+            total_forwards_period = sum(int(item.total_forwards or 0) for item in views_history)
+
+            avg_views_per_post = (
+                total_views_period / total_posts_period if total_posts_period > 0 else 0.0
+            )
+            avg_reactions_per_post = (
+                total_reactions_period / total_posts_period if total_posts_period > 0 else 0.0
+            )
+            avg_forwards_per_post = (
+                total_forwards_period / total_posts_period if total_posts_period > 0 else 0.0
+            )
+
+            # ER: реакция + репост от просмотров
+            engagement_rate = (
+                ((total_reactions_period + total_forwards_period) / total_views_period) * 100
+                if total_views_period > 0 else 0.0
+            )
+
+            # Контент-микс по постам периода
+            content_breakdown: Dict[str, Dict[str, float]] = {}
+            posts_by_hour: Dict[int, Dict[str, float]] = {}
+            posts_by_weekday: Dict[int, Dict[str, float]] = {}
+            post_engagement_rates: List[float] = []
+            top_posts: List[Dict[str, Any]] = []
+
+            for post in period_posts:
+                media_type = post.media_type or 'text'
+                post_views = int(post.views or 0)
+                post_forwards = int(post.forwards or 0)
+                post_reactions = 0
+                if isinstance(post.reactions, dict):
+                    post_reactions = sum(int(value or 0) for value in post.reactions.values())
+
+                if media_type not in content_breakdown:
+                    content_breakdown[media_type] = {
+                        'posts_count': 0,
+                        'total_views': 0,
+                        'total_reactions': 0,
+                        'avg_views': 0.0,
+                    }
+
+                content_breakdown[media_type]['posts_count'] += 1
+                content_breakdown[media_type]['total_views'] += post_views
+                content_breakdown[media_type]['total_reactions'] += post_reactions
+
+                hour = post.posted_at.hour
+                if hour not in posts_by_hour:
+                    posts_by_hour[hour] = {
+                        'posts_count': 0,
+                        'total_views': 0,
+                    }
+                posts_by_hour[hour]['posts_count'] += 1
+                posts_by_hour[hour]['total_views'] += post_views
+
+                weekday = post.posted_at.weekday()
+                if weekday not in posts_by_weekday:
+                    posts_by_weekday[weekday] = {
+                        'posts_count': 0,
+                        'total_views': 0,
+                    }
+                posts_by_weekday[weekday]['posts_count'] += 1
+                posts_by_weekday[weekday]['total_views'] += post_views
+
+                post_er = ((post_reactions + post_forwards) / post_views * 100) if post_views > 0 else 0.0
+                if post_views > 0:
+                    post_engagement_rates.append(post_er)
+                top_posts.append(
+                    {
+                        'id': post.post_id,
+                        'text': post.text[:120] + '...' if post.text and len(post.text) > 120 else post.text,
+                        'views': post_views,
+                        'forwards': post_forwards,
+                        'reactions_count': post_reactions,
+                        'engagement_rate': post_er,
+                        'media_type': media_type,
+                        'posted_at': post.posted_at.isoformat(),
+                    }
+                )
+
+            for media_stats in content_breakdown.values():
+                posts_count = int(media_stats['posts_count'])
+                media_stats['avg_views'] = (
+                    media_stats['total_views'] / posts_count if posts_count > 0 else 0.0
+                )
+
+            # Топ 5 постов по просмотрам
+            top_posts = sorted(top_posts, key=lambda item: item['views'], reverse=True)[:5]
+
+            best_posting_hour: Optional[int] = None
+            best_posting_hour_avg_views = 0.0
+            if posts_by_hour:
+                best_hour, best_data = max(
+                    posts_by_hour.items(),
+                    key=lambda item: (
+                        item[1]['total_views'] / item[1]['posts_count'] if item[1]['posts_count'] > 0 else 0
+                    ),
+                )
+                best_posting_hour = int(best_hour)
+                best_posting_hour_avg_views = (
+                    best_data['total_views'] / best_data['posts_count']
+                    if best_data['posts_count'] > 0 else 0.0
+                )
+
+            best_posting_weekday: Optional[int] = None
+            best_posting_weekday_avg_views = 0.0
+            if posts_by_weekday:
+                best_wd, best_wd_data = max(
+                    posts_by_weekday.items(),
+                    key=lambda item: (
+                        item[1]['total_views'] / item[1]['posts_count'] if item[1]['posts_count'] > 0 else 0
+                    ),
+                )
+                best_posting_weekday = int(best_wd)
+                best_posting_weekday_avg_views = (
+                    best_wd_data['total_views'] / best_wd_data['posts_count']
+                    if best_wd_data['posts_count'] > 0 else 0.0
+                )
+
+            # Расширенные ER-метрики:
+            #   ER (classic) — (реакции + репосты) / подписчики * 100
+            #   ERR          — (реакции + репосты) / просмотры  * 100  (= engagement_rate)
+            #   VTR          — средний охват поста / подписчики * 100  (Reach Rate)
+            current_subscribers = int(channel.subscribers_count or 0)
+            avg_posts_per_day = total_posts_period / days if days > 0 else 0.0
+
+            er_classic = (
+                ((total_reactions_period + total_forwards_period) / current_subscribers) * 100
+                if current_subscribers > 0 else 0.0
+            )
+            err = engagement_rate
+            vtr = (
+                (avg_views_per_post / current_subscribers) * 100
+                if current_subscribers > 0 and avg_views_per_post > 0 else 0.0
+            )
+            avg_post_er = (
+                sum(post_engagement_rates) / len(post_engagement_rates)
+                if post_engagement_rates else 0.0
+            )
+
             return {
                 'channel': {
                     'id': channel.channel_id,
@@ -284,6 +471,34 @@ class DatabaseService:
                     'title': channel.title,
                     'subscribers': channel.subscribers_count,
                     'posts_count': channel.posts_count
+                },
+                'period': {
+                    'days': days,
+                    'start_date': start_date.isoformat(),
+                    'members_total_growth': members_total_growth,
+                    'members_growth_percent': members_growth_percent,
+                    'avg_daily_growth': avg_daily_growth,
+                    'growth_days': growth_days,
+                    'decline_days': decline_days,
+                    'stable_days': stable_days,
+                    'total_posts': total_posts_period,
+                    'total_views': total_views_period,
+                    'total_reactions': total_reactions_period,
+                    'total_forwards': total_forwards_period,
+                    'avg_views_per_post': avg_views_per_post,
+                    'avg_reactions_per_post': avg_reactions_per_post,
+                    'avg_forwards_per_post': avg_forwards_per_post,
+                    'engagement_rate': engagement_rate,
+                    'er_classic': er_classic,
+                    'err': err,
+                    'vtr': vtr,
+                    'avg_post_er': avg_post_er,
+                    'avg_posts_per_day': avg_posts_per_day,
+                    'current_subscribers': current_subscribers,
+                    'best_posting_hour': best_posting_hour,
+                    'best_posting_hour_avg_views': best_posting_hour_avg_views,
+                    'best_posting_weekday': best_posting_weekday,
+                    'best_posting_weekday_avg_views': best_posting_weekday_avg_views,
                 },
                 'members_history': [
                     {
@@ -308,7 +523,25 @@ class DatabaseService:
                         'forwards': p.forwards,
                         'posted_at': p.posted_at.isoformat()
                     } for p in recent_posts
-                ]
+                ],
+                'top_posts': top_posts,
+                'content_breakdown': content_breakdown,
+                'posts_by_hour': {
+                    int(hour): {
+                        'posts_count': int(stats['posts_count']),
+                        'avg_views': stats['total_views'] / stats['posts_count']
+                        if stats['posts_count'] > 0 else 0.0,
+                    }
+                    for hour, stats in posts_by_hour.items()
+                },
+                'posts_by_weekday': {
+                    int(weekday): {
+                        'posts_count': int(stats['posts_count']),
+                        'avg_views': stats['total_views'] / stats['posts_count']
+                        if stats['posts_count'] > 0 else 0.0,
+                    }
+                    for weekday, stats in posts_by_weekday.items()
+                },
             }
     
     async def close(self):

--- a/src/handlers/analytics_charts.py
+++ b/src/handlers/analytics_charts.py
@@ -1,0 +1,299 @@
+"""
+Генератор графиков аналитики канала в виде PNG (BytesIO).
+
+Все графики строятся через matplotlib с backend "Agg",
+чтобы работало в headless-окружении (Railway, Docker, CI).
+"""
+from __future__ import annotations
+
+import io
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend, должен быть выставлен до pyplot
+
+import matplotlib.dates as mdates  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+WEEKDAYS_RU = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+
+
+def _setup_style() -> None:
+    plt.rcParams["font.family"] = ["DejaVu Sans", "Arial Unicode MS", "Tahoma"]
+    plt.rcParams["axes.unicode_minus"] = False
+    plt.rcParams["figure.facecolor"] = "white"
+    plt.rcParams["axes.facecolor"] = "#f9fafb"
+    plt.rcParams["axes.edgecolor"] = "#cbd5e1"
+    plt.rcParams["axes.grid"] = True
+    plt.rcParams["grid.color"] = "#e2e8f0"
+    plt.rcParams["grid.linestyle"] = "--"
+    plt.rcParams["grid.linewidth"] = 0.6
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _empty_axis(ax, message: str) -> None:
+    ax.text(
+        0.5,
+        0.5,
+        message,
+        ha="center",
+        va="center",
+        transform=ax.transAxes,
+        fontsize=12,
+        color="#94a3b8",
+    )
+    ax.set_xticks([])
+    ax.set_yticks([])
+
+
+def _annotate_bars(ax, bars, formatter=lambda value: f"{value:,.0f}") -> None:
+    for bar in bars:
+        height = bar.get_height()
+        if height == 0:
+            continue
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height,
+            formatter(height),
+            ha="center",
+            va="bottom",
+            fontsize=9,
+            fontweight="bold",
+            color="#1f2937",
+        )
+
+
+def _plot_members(ax, members_history: List[Dict[str, Any]]) -> None:
+    ax.set_title("👥 Подписчики", fontsize=13, fontweight="bold")
+    if not members_history:
+        _empty_axis(ax, "Нет данных")
+        return
+
+    dates = [_parse_date(item["date"]) for item in members_history]
+    values = [int(item["count"]) for item in members_history]
+
+    ax.plot(dates, values, color="#2563eb", linewidth=2.2, marker="o", markersize=4)
+    ax.fill_between(dates, values, color="#2563eb", alpha=0.12)
+    ax.set_ylabel("Подписчики")
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%d.%m"))
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator(maxticks=8))
+
+
+def _plot_views(ax, views_history: List[Dict[str, Any]]) -> None:
+    ax.set_title("👁 Средний охват поста", fontsize=13, fontweight="bold")
+    if not views_history:
+        _empty_axis(ax, "Нет данных")
+        return
+
+    dates = [_parse_date(item["date"]) for item in views_history]
+    values = [float(item.get("avg_views") or 0) for item in views_history]
+
+    bars = ax.bar(dates, values, color="#10b981", alpha=0.85, width=0.7)
+    _annotate_bars(ax, bars)
+    ax.set_ylabel("Просмотры")
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%d.%m"))
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator(maxticks=8))
+
+
+def _plot_engagement(ax, period: Dict[str, Any]) -> None:
+    ax.set_title("🎯 Engagement Rate", fontsize=13, fontweight="bold")
+
+    er_classic = float(period.get("er_classic") or 0.0)
+    err = float(period.get("err") or 0.0)
+    vtr = float(period.get("vtr") or 0.0)
+    avg_post_er = float(period.get("avg_post_er") or 0.0)
+
+    labels = ["ER classic", "ERR (по\nпросмотрам)", "VTR\n(охват)", "Средний\nER поста"]
+    values = [er_classic, err, vtr, avg_post_er]
+    colors = ["#f59e0b", "#3b82f6", "#8b5cf6", "#ef4444"]
+
+    if all(value == 0 for value in values):
+        _empty_axis(ax, "Нет данных")
+        return
+
+    bars = ax.bar(labels, values, color=colors, alpha=0.85)
+    _annotate_bars(ax, bars, formatter=lambda value: f"{value:.2f}%")
+    ax.set_ylabel("Процент")
+    ax.set_ylim(0, max(values) * 1.25 if max(values) > 0 else 1)
+
+
+def _plot_content_mix(ax, content_breakdown: Dict[str, Dict[str, Any]]) -> None:
+    ax.set_title("🧩 Контент-микс", fontsize=13, fontweight="bold")
+
+    if not content_breakdown:
+        _empty_axis(ax, "Нет постов в периоде")
+        return
+
+    sorted_items = sorted(
+        content_breakdown.items(),
+        key=lambda item: item[1].get("posts_count", 0),
+        reverse=True,
+    )
+    labels = [item[0] for item in sorted_items]
+    sizes = [int(item[1].get("posts_count", 0)) for item in sorted_items]
+    palette = ["#2563eb", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#0ea5e9", "#22c55e"]
+    colors = [palette[i % len(palette)] for i in range(len(labels))]
+
+    ax.pie(
+        sizes,
+        labels=labels,
+        colors=colors,
+        autopct="%1.1f%%",
+        startangle=90,
+        textprops={"fontsize": 10},
+    )
+    ax.axis("equal")
+
+
+def _plot_best_hours(ax, posts_by_hour: Dict[int, Dict[str, Any]]) -> None:
+    ax.set_title("⏰ Средний охват по часам", fontsize=13, fontweight="bold")
+
+    if not posts_by_hour:
+        _empty_axis(ax, "Нет данных")
+        return
+
+    hours = list(range(24))
+    avg_views = [float(posts_by_hour.get(hour, {}).get("avg_views") or 0) for hour in hours]
+
+    if all(value == 0 for value in avg_views):
+        _empty_axis(ax, "Нет данных")
+        return
+
+    bars = ax.bar(hours, avg_views, color="#6366f1", alpha=0.85)
+    best_index = max(range(24), key=lambda idx: avg_views[idx])
+    bars[best_index].set_color("#f97316")
+    ax.set_xticks(range(0, 24, 2))
+    ax.set_xlabel("Час суток")
+    ax.set_ylabel("Средний охват поста")
+
+
+def _plot_best_weekdays(ax, posts_by_weekday: Dict[int, Dict[str, Any]]) -> None:
+    ax.set_title("📅 Средний охват по дням недели", fontsize=13, fontweight="bold")
+
+    if not posts_by_weekday:
+        _empty_axis(ax, "Нет данных")
+        return
+
+    indices = list(range(7))
+    avg_views = [float(posts_by_weekday.get(index, {}).get("avg_views") or 0) for index in indices]
+
+    if all(value == 0 for value in avg_views):
+        _empty_axis(ax, "Нет данных")
+        return
+
+    bars = ax.bar(WEEKDAYS_RU, avg_views, color="#0ea5e9", alpha=0.85)
+    best_index = max(indices, key=lambda idx: avg_views[idx])
+    bars[best_index].set_color("#f97316")
+    ax.set_ylabel("Средний охват поста")
+
+
+def render_channel_dashboard_png(analytics: Dict[str, Any]) -> Optional[io.BytesIO]:
+    """
+    Строит сводный дашборд канала и возвращает PNG в BytesIO.
+
+    Возвращает None, если данных слишком мало для построения.
+    """
+    if not analytics:
+        return None
+
+    channel = analytics.get("channel") or {}
+    period = analytics.get("period") or {}
+    members_history = analytics.get("members_history") or []
+    views_history = analytics.get("views_history") or []
+    content_breakdown = analytics.get("content_breakdown") or {}
+    posts_by_hour = analytics.get("posts_by_hour") or {}
+    posts_by_weekday = analytics.get("posts_by_weekday") or {}
+
+    if not any([members_history, views_history, content_breakdown, posts_by_hour]):
+        return None
+
+    _setup_style()
+
+    fig, axes = plt.subplots(3, 2, figsize=(13, 14))
+    fig.subplots_adjust(hspace=0.55, wspace=0.3, top=0.92, bottom=0.06, left=0.07, right=0.97)
+
+    title = channel.get("title") or "Канал"
+    username = channel.get("username")
+    days = period.get("days") or 7
+    header = f"📊 Аналитика канала «{title}» за {days} дн."
+    if username:
+        header += f"  ·  @{username}"
+    fig.suptitle(header, fontsize=16, fontweight="bold")
+
+    _plot_members(axes[0][0], members_history)
+    _plot_views(axes[0][1], views_history)
+    _plot_engagement(axes[1][0], period)
+    _plot_content_mix(axes[1][1], content_breakdown)
+    _plot_best_hours(axes[2][0], posts_by_hour)
+    _plot_best_weekdays(axes[2][1], posts_by_weekday)
+
+    fig.text(
+        0.5,
+        0.015,
+        f"Сгенерировано: {datetime.now().strftime('%d.%m.%Y %H:%M')}",
+        ha="center",
+        fontsize=9,
+        color="#64748b",
+    )
+
+    buffer = io.BytesIO()
+    try:
+        fig.savefig(buffer, format="png", dpi=150, bbox_inches="tight")
+    finally:
+        plt.close(fig)
+
+    buffer.seek(0)
+    return buffer
+
+
+def render_growth_overview_png(rows: List[Dict[str, Any]]) -> Optional[io.BytesIO]:
+    """
+    Строит сравнительный график роста по всем активным каналам.
+    rows: список словарей с ключами title/username/growth/growth_percent/engagement_rate.
+    """
+    if not rows:
+        return None
+
+    _setup_style()
+
+    sorted_rows = sorted(rows, key=lambda item: item.get("growth", 0), reverse=True)
+    labels = [
+        f"@{row['username']}" if row.get("username") else (row.get("title") or "—")
+        for row in sorted_rows
+    ]
+    growth_values = [int(row.get("growth", 0)) for row in sorted_rows]
+    er_values = [float(row.get("engagement_rate", 0.0)) for row in sorted_rows]
+
+    fig, (ax_growth, ax_er) = plt.subplots(2, 1, figsize=(12, 8))
+    fig.subplots_adjust(hspace=0.5, top=0.92)
+    fig.suptitle("📈 Рост и вовлеченность каналов за 7 дней", fontsize=15, fontweight="bold")
+
+    growth_colors = ["#10b981" if value >= 0 else "#ef4444" for value in growth_values]
+    bars = ax_growth.bar(labels, growth_values, color=growth_colors, alpha=0.85)
+    ax_growth.axhline(0, color="#64748b", linewidth=0.8)
+    ax_growth.set_title("Прирост подписчиков", fontsize=12, fontweight="bold")
+    ax_growth.set_ylabel("Подписчики")
+    ax_growth.tick_params(axis="x", rotation=30)
+    _annotate_bars(ax_growth, bars, formatter=lambda value: f"{int(value):+,}")
+
+    er_bars = ax_er.bar(labels, er_values, color="#3b82f6", alpha=0.85)
+    ax_er.set_title("Engagement Rate (ERR)", fontsize=12, fontweight="bold")
+    ax_er.set_ylabel("ERR, %")
+    ax_er.tick_params(axis="x", rotation=30)
+    _annotate_bars(ax_er, er_bars, formatter=lambda value: f"{value:.2f}%")
+
+    buffer = io.BytesIO()
+    try:
+        fig.savefig(buffer, format="png", dpi=150, bbox_inches="tight")
+    finally:
+        plt.close(fig)
+    buffer.seek(0)
+    return buffer

--- a/src/handlers/analytics_commands.py
+++ b/src/handlers/analytics_commands.py
@@ -8,13 +8,24 @@ from typing import List, Optional, Dict, Any
 from datetime import datetime, date, timedelta
 
 from aiogram import Router, F
-from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.types import (
+    Message,
+    CallbackQuery,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    BufferedInputFile,
+)
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 
 from ..db.database_service import DatabaseService
 from ..config import settings
+from .analytics_charts import (
+    render_channel_dashboard_png,
+    render_growth_overview_png,
+    WEEKDAYS_RU,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +135,29 @@ class AnalyticsCommands:
         async def channels_command(message: Message):
             """Публичный список каналов"""
             await self.show_public_channels_list(message)
+
+        @self.router.message(Command("chart"))
+        async def chart_command(message: Message):
+            """Сводный график-дашборд по каналу."""
+            args = message.text.split()[1:] if len(message.text.split()) > 1 else []
+            if not args:
+                await message.answer(
+                    "📊 <b>График канала</b>\n\n"
+                    "Использование: <code>/chart @channel [дни]</code>\n\n"
+                    "Пример: <code>/chart @durov 30</code>",
+                    parse_mode="HTML",
+                )
+                return
+
+            channel_input = args[0]
+            days = int(args[1]) if len(args) > 1 and args[1].isdigit() else 7
+            days = min(days, 365)
+            await self.send_channel_chart(message, channel_input, days)
+
+        @self.router.message(Command("growth_chart"))
+        async def growth_chart_command(message: Message):
+            """Сравнительный график роста всех каналов."""
+            await self.send_growth_chart(message)
         
         # Callback обработчики
         @self.router.callback_query(F.data.startswith("channel_"))
@@ -263,6 +297,8 @@ class AnalyticsCommands:
                 channel_id = await self.get_channel_id_by_username(username)
             elif channel_input.startswith('-100'):
                 channel_id = int(channel_input)
+            elif channel_input.lstrip('-').isdigit():
+                channel_id = int(channel_input)
             else:
                 await message.answer("❌ Неверный формат канала")
                 return
@@ -281,6 +317,9 @@ class AnalyticsCommands:
             channel_info = analytics['channel']
             members_history = analytics['members_history']
             views_history = analytics['views_history']
+            period = analytics.get('period', {})
+            content_breakdown = analytics.get('content_breakdown', {})
+            top_posts = analytics.get('top_posts', [])
             
             # Формируем отчет
             text = f"📊 <b>Статистика канала за {days} дней</b>\n\n"
@@ -294,33 +333,77 @@ class AnalyticsCommands:
             text += f"📝 <b>Постов:</b> {channel_info['posts_count']:,}\n\n"
             
             # Динамика подписчиков
-            if members_history:
-                first_day = members_history[0]
-                last_day = members_history[-1]
-                growth = last_day['count'] - first_day['count']
-                growth_percent = (growth / first_day['count'] * 100) if first_day['count'] > 0 else 0
-                
+            if period:
                 text += f"📈 <b>Рост подписчиков:</b>\n"
-                text += f"   • За период: {growth:+,} ({growth_percent:+.1f}%)\n"
-                text += f"   • В день: {growth / days:+.1f} в среднем\n\n"
+                text += f"   • За период: {period.get('members_total_growth', 0):+,} ({period.get('members_growth_percent', 0):+.1f}%)\n"
+                text += f"   • В день (среднее): {period.get('avg_daily_growth', 0):+.1f}\n"
+                text += f"   • Дней роста/падения/стабильных: {period.get('growth_days', 0)}/{period.get('decline_days', 0)}/{period.get('stable_days', 0)}\n\n"
             
             # Просмотры
-            if views_history:
-                avg_views = sum(v['avg_views'] for v in views_history) / len(views_history)
-                total_posts = sum(v['posts_count'] for v in views_history)
-                
-                text += f"👁 <b>Просмотры:</b>\n"
-                text += f"   • Среднее за пост: {avg_views:,.0f}\n"
-                text += f"   • Постов за период: {total_posts}\n\n"
+            if period:
+                text += f"👁 <b>Охваты и вовлеченность:</b>\n"
+                text += f"   • Постов за период: {period.get('total_posts', 0):,} (≈ {period.get('avg_posts_per_day', 0):.1f}/день)\n"
+                text += f"   • Суммарные просмотры: {period.get('total_views', 0):,}\n"
+                text += f"   • Средний охват поста: {period.get('avg_views_per_post', 0):,.0f}\n"
+                text += f"   • Средние реакции/репосты: {period.get('avg_reactions_per_post', 0):.1f}/{period.get('avg_forwards_per_post', 0):.1f}\n"
+                text += "\n"
+
+                text += f"🎯 <b>ER-метрики:</b>\n"
+                text += f"   • ER classic (от подписчиков): {period.get('er_classic', 0):.2f}%\n"
+                text += f"   • ERR (от просмотров): {period.get('err', 0):.2f}%\n"
+                text += f"   • VTR/Reach Rate (охват/подписчики): {period.get('vtr', 0):.2f}%\n"
+                text += f"   • Средний ER поста: {period.get('avg_post_er', 0):.2f}%\n\n"
+
+                best_hour = period.get('best_posting_hour')
+                best_wd = period.get('best_posting_weekday')
+                if best_hour is not None or best_wd is not None:
+                    text += "⏰ <b>Лучшее время публикации:</b>\n"
+                    if best_hour is not None:
+                        text += (
+                            f"   • Час: {int(best_hour):02d}:00 "
+                            f"(ср. {period.get('best_posting_hour_avg_views', 0):,.0f} просмотров)\n"
+                        )
+                    if best_wd is not None:
+                        weekday_name = WEEKDAYS_RU[int(best_wd)] if 0 <= int(best_wd) < 7 else str(best_wd)
+                        text += (
+                            f"   • День недели: {weekday_name} "
+                            f"(ср. {period.get('best_posting_weekday_avg_views', 0):,.0f} просмотров)\n"
+                        )
+                    text += "\n"
+
+            if content_breakdown:
+                text += "🧩 <b>Контент-микс:</b>\n"
+                sorted_content = sorted(
+                    content_breakdown.items(),
+                    key=lambda item: item[1].get('posts_count', 0),
+                    reverse=True,
+                )
+                for content_type, stats in sorted_content[:5]:
+                    text += (
+                        f"   • {content_type}: {int(stats.get('posts_count', 0))} постов"
+                        f", ср. {stats.get('avg_views', 0):,.0f} просмотров\n"
+                    )
+                text += "\n"
             
-            # Последние посты
-            recent_posts = analytics['recent_posts'][:3]
-            if recent_posts:
-                text += f"📝 <b>Последние посты:</b>\n"
-                for post in recent_posts:
+            # Топ постов
+            if top_posts:
+                text += "🏆 <b>Топ постов по охвату:</b>\n"
+                for post in top_posts[:3]:
                     post_text = post['text'][:50] + '...' if post['text'] and len(post['text']) > 50 else (post['text'] or 'Без текста')
-                    text += f"   • {post_text}\n"
-                    text += f"     👁 {post['views']:,} | 🔄 {post['forwards']:,}\n"
+                    text += (
+                        f"   • {post_text}\n"
+                        f"     👁 {int(post['views']):,} | 👍 {int(post.get('reactions_count', 0)):,} | "
+                        f"🔄 {int(post['forwards']):,} | ER {post.get('engagement_rate', 0):.2f}%\n"
+                    )
+
+            # Авто-рекомендации
+            recommendations = self._build_recommendations(period, content_breakdown, top_posts)
+            if recommendations:
+                text += "\n💡 <b>Рекомендации:</b>\n"
+                for tip in recommendations:
+                    text += f"   • {tip}\n"
+
+            text += f"\n🕐 <i>Обновлено: {datetime.now().strftime('%d.%m.%Y %H:%M')}</i>"
             
             # Inline кнопки для дополнительных действий
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
@@ -341,45 +424,172 @@ class AnalyticsCommands:
             await message.answer(f"❌ Ошибка получения статистики: {str(e)}")
     
     async def show_summary(self, message: Message):
-        """Показать общую сводку по всем каналам"""
+        """Показать общую сводку по всем каналам с ER-метриками."""
         try:
             channels = await self.db.get_active_channels()
-            
+
             if not channels:
                 await message.answer("📊 Нет каналов в мониторинге")
                 return
-            
-            text = f"📊 <b>Сводка по {len(channels)} каналам</b>\n\n"
-            
-            total_subscribers = sum(ch.subscribers_count for ch in channels)
-            total_posts = sum(ch.posts_count for ch in channels)
-            
-            text += f"👥 <b>Общие показатели:</b>\n"
-            text += f"   • Подписчики: {total_subscribers:,}\n"
-            text += f"   • Посты: {total_posts:,}\n"
-            text += f"   • Среднее на канал: {total_subscribers // len(channels):,}\n\n"
-            
-            # Топ каналов по подписчикам
-            top_channels = sorted(channels, key=lambda x: x.subscribers_count, reverse=True)[:5]
-            text += f"🏆 <b>Топ каналов по подписчикам:</b>\n"
-            for i, ch in enumerate(top_channels, 1):
-                username_display = f"@{ch.username}" if ch.username else ch.title[:20]
-                text += f"   {i}. {username_display} - {ch.subscribers_count:,}\n"
-            
-            await message.answer(text, parse_mode="HTML")
-            
+
+            rows: List[Dict[str, Any]] = []
+            for channel in channels:
+                analytics = await self.db.get_channel_analytics(channel.channel_id, 7)
+                period = (analytics or {}).get("period", {}) if analytics else {}
+                rows.append(
+                    {
+                        "channel": channel,
+                        "title": channel.title or (
+                            f"@{channel.username}" if channel.username else str(channel.channel_id)
+                        ),
+                        "username": channel.username,
+                        "subscribers": int(channel.subscribers_count or 0),
+                        "growth": int(period.get("members_total_growth", 0) or 0),
+                        "growth_percent": float(period.get("members_growth_percent", 0.0) or 0.0),
+                        "engagement_rate": float(period.get("engagement_rate", 0.0) or 0.0),
+                        "er_classic": float(period.get("er_classic", 0.0) or 0.0),
+                        "vtr": float(period.get("vtr", 0.0) or 0.0),
+                        "avg_views_per_post": float(period.get("avg_views_per_post", 0.0) or 0.0),
+                        "total_posts": int(period.get("total_posts", 0) or 0),
+                    }
+                )
+
+            total_channels = len(rows)
+            total_subscribers = sum(item["subscribers"] for item in rows)
+            total_growth = sum(item["growth"] for item in rows)
+            total_posts = sum(item["total_posts"] for item in rows)
+
+            channels_with_er = [item for item in rows if item["engagement_rate"] > 0]
+            avg_err = (
+                sum(item["engagement_rate"] for item in channels_with_er) / len(channels_with_er)
+                if channels_with_er else 0.0
+            )
+            channels_with_vtr = [item for item in rows if item["vtr"] > 0]
+            avg_vtr = (
+                sum(item["vtr"] for item in channels_with_vtr) / len(channels_with_vtr)
+                if channels_with_vtr else 0.0
+            )
+            avg_views = (
+                sum(item["avg_views_per_post"] for item in rows if item["avg_views_per_post"] > 0)
+                / max(1, sum(1 for item in rows if item["avg_views_per_post"] > 0))
+            )
+
+            text = f"📊 <b>Сводка по {total_channels} каналам · 7 дней</b>\n\n"
+            text += "👥 <b>Аудитория:</b>\n"
+            text += f"   • Всего подписчиков: {total_subscribers:,}\n"
+            text += f"   • Средне на канал: {total_subscribers // max(1, total_channels):,}\n"
+            text += f"   • Прирост за 7 дн.: {total_growth:+,}\n\n"
+
+            text += "📝 <b>Активность:</b>\n"
+            text += f"   • Постов за период: {total_posts:,}\n"
+            text += f"   • Средний охват поста: {avg_views:,.0f}\n\n"
+
+            text += "🎯 <b>Вовлеченность (среднее по каналам):</b>\n"
+            text += f"   • ERR: {avg_err:.2f}%\n"
+            text += f"   • VTR / Reach Rate: {avg_vtr:.2f}%\n\n"
+
+            top_subscribers = sorted(rows, key=lambda item: item["subscribers"], reverse=True)[:5]
+            text += "🏆 <b>Топ по подписчикам:</b>\n"
+            for index, item in enumerate(top_subscribers, 1):
+                name = f"@{item['username']}" if item["username"] else item["title"][:24]
+                text += f"   {index}. {name} — {item['subscribers']:,}\n"
+
+            top_er = sorted(rows, key=lambda item: item["engagement_rate"], reverse=True)[:3]
+            if any(item["engagement_rate"] > 0 for item in top_er):
+                text += "\n💎 <b>Топ по ERR:</b>\n"
+                for item in top_er:
+                    if item["engagement_rate"] <= 0:
+                        continue
+                    name = f"@{item['username']}" if item["username"] else item["title"][:24]
+                    text += f"   • {name} — {item['engagement_rate']:.2f}%\n"
+
+            top_growth = sorted(rows, key=lambda item: item["growth"], reverse=True)[:3]
+            text += "\n🚀 <b>Лидеры роста:</b>\n"
+            for item in top_growth:
+                name = f"@{item['username']}" if item["username"] else item["title"][:24]
+                text += f"   • {name}: {item['growth']:+,} ({item['growth_percent']:+.2f}%)\n"
+
+            keyboard = InlineKeyboardMarkup(
+                inline_keyboard=[
+                    [
+                        InlineKeyboardButton(text="📈 Графики роста", callback_data="growth_chart"),
+                        InlineKeyboardButton(text="📊 Сводка-картинка", callback_data="summary_chart"),
+                    ]
+                ]
+            )
+
+            await message.answer(text, parse_mode="HTML", reply_markup=keyboard)
+
         except Exception as e:
             logger.error(f"Ошибка получения сводки: {e}")
             await message.answer(f"❌ Ошибка получения сводки: {str(e)}")
+
+    async def send_summary_chart(self, message: Message) -> None:
+        """Отправка сводного графика по всем каналам (тот же growth overview)."""
+        await self.send_growth_chart(message)
     
     async def show_growth_stats(self, message: Message):
         """Показать статистику роста"""
-        await message.answer(
-            "📈 <b>Статистика роста</b>\n\n"
-            "🚧 Функция в разработке\n"
-            "Скоро будет доступен подробный анализ роста всех каналов",
-            parse_mode="HTML"
-        )
+        try:
+            channels = await self.db.get_active_channels()
+            if not channels:
+                await message.answer("📈 Нет каналов в мониторинге", parse_mode="HTML")
+                return
+
+            analytics_rows = []
+            for channel in channels:
+                analytics = await self.db.get_channel_analytics(channel.channel_id, 7)
+                if not analytics:
+                    continue
+
+                period = analytics.get('period', {})
+                analytics_rows.append(
+                    {
+                        'title': channel.title or (f"@{channel.username}" if channel.username else str(channel.channel_id)),
+                        'username': channel.username,
+                        'growth': int(period.get('members_total_growth', 0)),
+                        'growth_percent': float(period.get('members_growth_percent', 0.0)),
+                        'engagement_rate': float(period.get('engagement_rate', 0.0)),
+                        'avg_views_per_post': float(period.get('avg_views_per_post', 0.0)),
+                    }
+                )
+
+            if not analytics_rows:
+                await message.answer("📈 Недостаточно данных для анализа роста за 7 дней", parse_mode="HTML")
+                return
+
+            total_growth = sum(item['growth'] for item in analytics_rows)
+            avg_growth_percent = sum(item['growth_percent'] for item in analytics_rows) / len(analytics_rows)
+            avg_er = sum(item['engagement_rate'] for item in analytics_rows) / len(analytics_rows)
+
+            top_growth = sorted(analytics_rows, key=lambda item: item['growth'], reverse=True)[:3]
+            top_decline = sorted(analytics_rows, key=lambda item: item['growth'])[:3]
+
+            text = "📈 <b>Рост каналов за 7 дней</b>\n\n"
+            text += "🧮 <b>Общая динамика:</b>\n"
+            text += f"   • Суммарный рост: {total_growth:+,}\n"
+            text += f"   • Средний рост, %: {avg_growth_percent:+.2f}%\n"
+            text += f"   • Средний ER: {avg_er:.2f}%\n\n"
+
+            text += "🚀 <b>Лидеры роста:</b>\n"
+            for row in top_growth:
+                name = f"@{row['username']}" if row['username'] else row['title']
+                text += f"   • {name}: {row['growth']:+,} ({row['growth_percent']:+.2f}%)\n"
+
+            text += "\n⚠️ <b>Зоны риска:</b>\n"
+            for row in top_decline:
+                name = f"@{row['username']}" if row['username'] else row['title']
+                text += f"   • {name}: {row['growth']:+,} ({row['growth_percent']:+.2f}%)\n"
+
+            keyboard = InlineKeyboardMarkup(inline_keyboard=[
+                [InlineKeyboardButton(text="📈 График роста", callback_data="growth_chart")],
+            ])
+
+            await message.answer(text, parse_mode="HTML", reply_markup=keyboard)
+
+        except Exception as e:
+            logger.error(f"Ошибка статистики роста: {e}")
+            await message.answer(f"❌ Ошибка статистики роста: {str(e)}", parse_mode="HTML")
     
     async def show_public_channels_list(self, message: Message):
         """Публичный список каналов (для всех пользователей)"""
@@ -412,43 +622,200 @@ class AnalyticsCommands:
         """Обработка callback запросов"""
         try:
             data = callback.data
-            
+
             if data == "summary_all":
                 await self.show_summary(callback.message)
+            elif data == "summary_chart":
+                await self.send_summary_chart(callback.message)
             elif data == "growth_all":
                 await self.show_growth_stats(callback.message)
+            elif data == "growth_chart":
+                await self.send_growth_chart(callback.message)
             elif data == "refresh_list":
                 await self.show_channels_list(callback.message)
             elif data.startswith("stats_"):
                 parts = data.split("_")
                 channel_id = int(parts[1])
                 days = int(parts[2])
-                # Здесь нужно получить username по channel_id
                 await self.show_channel_stats(callback.message, str(channel_id), days)
-            
+            elif data.startswith("chart_"):
+                parts = data.split("_")
+                channel_id = int(parts[1])
+                days = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 7
+                await self.send_channel_chart(callback.message, str(channel_id), days)
+
             await callback.answer()
-            
+
         except Exception as e:
             logger.error(f"Ошибка обработки callback: {e}")
             await callback.answer("❌ Ошибка обработки запроса")
     
     # === ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ ===
-    
+
+    def _build_recommendations(
+        self,
+        period: Dict[str, Any],
+        content_breakdown: Dict[str, Any],
+        top_posts: List[Dict[str, Any]],
+    ) -> List[str]:
+        """Формирование контекстных рекомендаций по порогам."""
+        tips: List[str] = []
+        if not period:
+            return tips
+
+        er_classic = float(period.get("er_classic") or 0.0)
+        err = float(period.get("err") or 0.0)
+        vtr = float(period.get("vtr") or 0.0)
+        growth_percent = float(period.get("members_growth_percent") or 0.0)
+        avg_posts_per_day = float(period.get("avg_posts_per_day") or 0.0)
+        total_posts = int(period.get("total_posts") or 0)
+
+        if er_classic and er_classic < 1.0:
+            tips.append("ER classic ниже 1% — пересмотреть форматы и СTA постов")
+        elif er_classic and er_classic > 5.0:
+            tips.append("Высокий ER classic — сохранить рубрики и регулярность")
+
+        if vtr and vtr < 20.0:
+            tips.append("Reach Rate < 20% — проверить уведомления и время выхода постов")
+
+        if err and err < 1.5:
+            tips.append("ERR ниже 1.5% — добавить опросы, реакции, обсуждения")
+
+        if growth_percent < 0:
+            tips.append("Подписчики уменьшаются — запустить контент-эксперимент или промо")
+        elif 0 <= growth_percent < 1:
+            tips.append("Рост подписчиков замедлен — усилить вирусные форматы и взаимные пиары")
+
+        if total_posts == 0:
+            tips.append("Нет постов в периоде — восстановить регулярный график публикаций")
+        elif avg_posts_per_day < 0.5:
+            tips.append("Меньше 1 поста за 2 дня — повысить частоту публикаций")
+        elif avg_posts_per_day > 5:
+            tips.append("Слишком много постов — риск выгорания аудитории, проверить дочитывания")
+
+        if content_breakdown:
+            best_type = max(
+                content_breakdown.items(),
+                key=lambda item: item[1].get("avg_views", 0),
+            )
+            type_name, type_stats = best_type
+            if type_stats.get("avg_views", 0) > 0:
+                tips.append(
+                    f"Лучший тип контента — {type_name} "
+                    f"(ср. {type_stats['avg_views']:,.0f} просмотров)"
+                )
+
+        if top_posts:
+            top = top_posts[0]
+            if top.get("engagement_rate", 0) > err and top.get("views", 0) > 0:
+                tips.append("Повторить формат лидера по охвату — он опережает средний ER")
+
+        return tips[:6]
+
+    async def send_channel_chart(
+        self,
+        message: Message,
+        channel_input: str,
+        days: int = 7,
+    ) -> None:
+        """Отправка графика-дашборда канала картинкой."""
+        try:
+            channel_id = await self._resolve_channel_id(channel_input)
+            if not channel_id:
+                await message.answer("❌ Канал не найден")
+                return
+
+            analytics = await self.db.get_channel_analytics(channel_id, days)
+            if not analytics:
+                await message.answer("❌ Нет данных по этому каналу")
+                return
+
+            buffer = await asyncio.to_thread(render_channel_dashboard_png, analytics)
+            if buffer is None:
+                await message.answer("⚠️ Недостаточно данных для графика")
+                return
+
+            channel_info = analytics.get("channel", {})
+            caption = (
+                f"📊 Дашборд «{channel_info.get('title') or channel_id}» за {days} дн."
+            )
+            file = BufferedInputFile(buffer.getvalue(), filename=f"channel_{channel_id}_{days}d.png")
+            await message.answer_photo(photo=file, caption=caption)
+
+        except Exception as e:
+            logger.error(f"Ошибка построения графика: {e}")
+            await message.answer(f"❌ Ошибка построения графика: {str(e)}")
+
+    async def send_growth_chart(self, message: Message) -> None:
+        """Отправка сравнительного графика роста по всем каналам."""
+        try:
+            channels = await self.db.get_active_channels()
+            if not channels:
+                await message.answer("📋 Нет каналов в мониторинге")
+                return
+
+            rows: List[Dict[str, Any]] = []
+            for channel in channels:
+                analytics = await self.db.get_channel_analytics(channel.channel_id, 7)
+                if not analytics:
+                    continue
+                period = analytics.get("period", {})
+                rows.append(
+                    {
+                        "title": channel.title or str(channel.channel_id),
+                        "username": channel.username,
+                        "growth": int(period.get("members_total_growth", 0) or 0),
+                        "growth_percent": float(period.get("members_growth_percent", 0.0) or 0.0),
+                        "engagement_rate": float(period.get("engagement_rate", 0.0) or 0.0),
+                    }
+                )
+
+            if not rows:
+                await message.answer("⚠️ Недостаточно данных для сравнительного графика")
+                return
+
+            buffer = await asyncio.to_thread(render_growth_overview_png, rows)
+            if buffer is None:
+                await message.answer("⚠️ Не удалось построить график")
+                return
+
+            file = BufferedInputFile(buffer.getvalue(), filename="growth_overview_7d.png")
+            await message.answer_photo(photo=file, caption="📈 Рост и вовлеченность каналов за 7 дн.")
+
+        except Exception as e:
+            logger.error(f"Ошибка построения графика роста: {e}")
+            await message.answer(f"❌ Ошибка графика роста: {str(e)}")
+
+    async def _resolve_channel_id(self, channel_input: str) -> Optional[int]:
+        """Разбор username/id канала в channel_id."""
+        if channel_input.startswith("@"):
+            return await self.get_channel_id_by_username(channel_input[1:])
+        if channel_input.lstrip("-").isdigit():
+            return int(channel_input)
+        return await self.get_channel_id_by_username(channel_input)
+
     async def get_channel_id_by_username(self, username: str) -> Optional[int]:
-        """Получение ID канала по username (заглушка)"""
-        # TODO: Реализовать через Telethon API
-        return None
+        """Получение ID канала по username из БД."""
+        channel = await self.db.get_channel_by_username(username)
+        return channel.channel_id if channel else None
     
     async def get_username_by_channel_id(self, channel_id: int) -> Optional[str]:
-        """Получение username по ID канала (заглушка)"""
-        # TODO: Реализовать через Telethon API
-        return None
+        """Получение username по ID канала из БД."""
+        channel = await self.db.get_channel(channel_id)
+        return channel.username if channel else None
     
     async def get_channel_info(self, channel_id: int) -> Dict[str, Any]:
-        """Получение информации о канале (заглушка)"""
-        # TODO: Реализовать через Telethon API
+        """Получение информации о канале из БД."""
+        channel = await self.db.get_channel(channel_id)
+        if not channel:
+            return {
+                'title': f'Канал {channel_id}',
+                'description': 'Описание недоступно',
+                'members_count': 0
+            }
+
         return {
-            'title': f'Канал {channel_id}',
-            'description': 'Описание недоступно',
-            'members_count': 0
+            'title': channel.title or f'Канал {channel_id}',
+            'description': channel.description or 'Описание недоступно',
+            'members_count': channel.subscribers_count
         }

--- a/tests/test_analytics_charts.py
+++ b/tests/test_analytics_charts.py
@@ -1,0 +1,130 @@
+"""Smoke-тесты для модуля построения графиков аналитики."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any, Dict
+
+from src.handlers.analytics_charts import (
+    render_channel_dashboard_png,
+    render_growth_overview_png,
+)
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _sample_analytics() -> Dict[str, Any]:
+    today = date.today()
+    return {
+        "channel": {
+            "id": 1,
+            "username": "demo",
+            "title": "Demo Channel",
+            "subscribers": 10000,
+            "posts_count": 200,
+        },
+        "period": {
+            "days": 7,
+            "members_total_growth": 120,
+            "members_growth_percent": 1.2,
+            "avg_daily_growth": 17.1,
+            "growth_days": 5,
+            "decline_days": 1,
+            "stable_days": 1,
+            "total_posts": 14,
+            "total_views": 56000,
+            "total_reactions": 1800,
+            "total_forwards": 220,
+            "avg_views_per_post": 4000,
+            "avg_reactions_per_post": 128.5,
+            "avg_forwards_per_post": 15.7,
+            "engagement_rate": 3.6,
+            "er_classic": 20.2,
+            "err": 3.6,
+            "vtr": 40.0,
+            "avg_post_er": 3.4,
+            "avg_posts_per_day": 2.0,
+            "current_subscribers": 10000,
+            "best_posting_hour": 19,
+            "best_posting_hour_avg_views": 5200,
+            "best_posting_weekday": 2,
+            "best_posting_weekday_avg_views": 4800,
+        },
+        "members_history": [
+            {
+                "date": (today - timedelta(days=i)).isoformat(),
+                "count": 9900 + i * 15,
+                "growth": 15,
+            }
+            for i in range(7, 0, -1)
+        ],
+        "views_history": [
+            {
+                "date": (today - timedelta(days=i)).isoformat(),
+                "avg_views": 3500 + i * 100,
+                "total_views": 7000 + i * 200,
+                "posts_count": 2,
+            }
+            for i in range(7, 0, -1)
+        ],
+        "content_breakdown": {
+            "text": {"posts_count": 6, "total_views": 18000, "total_reactions": 600, "avg_views": 3000},
+            "photo": {"posts_count": 5, "total_views": 22000, "total_reactions": 800, "avg_views": 4400},
+            "video": {"posts_count": 3, "total_views": 16000, "total_reactions": 400, "avg_views": 5333},
+        },
+        "posts_by_hour": {
+            hour: {"posts_count": 1, "avg_views": 3000 + (hour % 5) * 400}
+            for hour in [9, 12, 15, 18, 19, 21]
+        },
+        "posts_by_weekday": {
+            index: {"posts_count": 2, "avg_views": 3500 + index * 200} for index in range(7)
+        },
+        "top_posts": [],
+        "recent_posts": [],
+    }
+
+
+def test_render_channel_dashboard_png_returns_png_bytes() -> None:
+    buffer = render_channel_dashboard_png(_sample_analytics())
+
+    assert buffer is not None, "Дашборд должен строиться при наличии данных"
+    payload = buffer.getvalue()
+    assert payload.startswith(PNG_SIGNATURE), "Файл должен быть валидным PNG"
+    assert len(payload) > 5_000, "PNG не должен быть пустым"
+
+
+def test_render_channel_dashboard_returns_none_when_empty() -> None:
+    empty_analytics: Dict[str, Any] = {
+        "channel": {"title": "Empty"},
+        "period": {},
+        "members_history": [],
+        "views_history": [],
+        "content_breakdown": {},
+        "posts_by_hour": {},
+        "posts_by_weekday": {},
+    }
+
+    assert render_channel_dashboard_png(empty_analytics) is None
+
+
+def test_render_channel_dashboard_returns_none_for_falsy_input() -> None:
+    assert render_channel_dashboard_png({}) is None
+
+
+def test_render_growth_overview_png_returns_png_bytes() -> None:
+    rows = [
+        {"title": "Demo", "username": "demo", "growth": 120, "growth_percent": 1.2, "engagement_rate": 3.6},
+        {"title": "Other", "username": "other", "growth": -45, "growth_percent": -0.4, "engagement_rate": 2.1},
+        {"title": "News", "username": "news", "growth": 300, "growth_percent": 5.5, "engagement_rate": 4.8},
+    ]
+
+    buffer = render_growth_overview_png(rows)
+
+    assert buffer is not None
+    payload = buffer.getvalue()
+    assert payload.startswith(PNG_SIGNATURE)
+    assert len(payload) > 5_000
+
+
+def test_render_growth_overview_returns_none_for_empty_rows() -> None:
+    assert render_growth_overview_png([]) is None

--- a/tests/test_database_service_analytics.py
+++ b/tests/test_database_service_analytics.py
@@ -1,0 +1,175 @@
+"""Smoke-тесты для расчета расширенной аналитики канала.
+
+Тестируем чисто арифметическую часть `get_channel_analytics`, мокая
+session/Channel/Post/Members/Views, чтобы не требовать БД.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List
+
+import pytest
+
+from src.db.database_service import DatabaseService
+
+
+class _FakeScalars:
+    def __init__(self, items: List[Any]) -> None:
+        self._items = items
+
+    def all(self) -> List[Any]:
+        return list(self._items)
+
+    def scalar_one_or_none(self) -> Any:
+        return self._items[0] if self._items else None
+
+
+class _FakeResult:
+    def __init__(self, items: List[Any]) -> None:
+        self._items = items
+
+    def scalars(self) -> _FakeScalars:
+        return _FakeScalars(self._items)
+
+    def scalar_one_or_none(self) -> Any:
+        return self._items[0] if self._items else None
+
+
+class _FakeSession:
+    """Минимальная имитация AsyncSession для get_channel_analytics."""
+
+    def __init__(self, channel: Any, members: List[Any], views: List[Any], posts: List[Any]) -> None:
+        self._channel = channel
+        self._members = members
+        self._views = views
+        self._posts = posts
+        self._call_index = 0
+
+    async def execute(self, _stmt: Any) -> _FakeResult:
+        # Порядок запросов в get_channel_analytics:
+        # 1) channel, 2) members_history, 3) views_history,
+        # 4) period_posts, 5) recent_posts.
+        order = [
+            [self._channel] if self._channel else [],
+            self._members,
+            self._views,
+            self._posts,
+            list(reversed(self._posts))[:10],
+        ]
+        result = _FakeResult(order[self._call_index])
+        self._call_index += 1
+        return result
+
+
+class _SimpleAttr:
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _build_service_with_session(session: _FakeSession) -> DatabaseService:
+    service = DatabaseService("postgresql+asyncpg://test/test")
+
+    @asynccontextmanager
+    async def _session_factory():
+        yield session
+
+    service.get_session = _session_factory  # type: ignore[assignment]
+    return service
+
+
+def _make_post(message_id: int, hour: int, weekday_offset: int, views: int, reactions: int, forwards: int) -> _SimpleAttr:
+    base = datetime(2026, 5, 4, hour, 0)  # 4 May 2026 = Monday
+    return _SimpleAttr(
+        post_id=message_id,
+        text=f"post {message_id}",
+        media_type="photo" if message_id % 2 == 0 else "text",
+        views=views,
+        forwards=forwards,
+        reactions={"like": reactions},
+        posted_at=base + timedelta(days=weekday_offset),
+    )
+
+
+@pytest.mark.asyncio
+async def test_channel_analytics_period_metrics() -> None:
+    today = date.today()
+
+    channel = _SimpleAttr(
+        channel_id=1,
+        username="demo",
+        title="Demo",
+        subscribers_count=1000,
+        posts_count=10,
+    )
+    members = [
+        _SimpleAttr(date=datetime.combine(today - timedelta(days=offset), datetime.min.time()),
+                    members_count=1000 - offset * 10,
+                    members_growth=10)
+        for offset in range(6, -1, -1)
+    ]
+    views = [
+        _SimpleAttr(date=datetime.combine(today - timedelta(days=offset), datetime.min.time()),
+                    avg_views=200,
+                    total_views=400,
+                    posts_count=2,
+                    total_reactions=20,
+                    total_forwards=4)
+        for offset in range(6, -1, -1)
+    ]
+    posts = [
+        _make_post(1, hour=10, weekday_offset=0, views=500, reactions=20, forwards=5),
+        _make_post(2, hour=19, weekday_offset=1, views=900, reactions=60, forwards=10),
+        _make_post(3, hour=19, weekday_offset=1, views=1100, reactions=80, forwards=15),
+        _make_post(4, hour=12, weekday_offset=2, views=300, reactions=10, forwards=2),
+    ]
+
+    session = _FakeSession(channel, members, views, posts)
+    service = _build_service_with_session(session)
+
+    analytics = await service.get_channel_analytics(channel_id=1, days=7)
+
+    assert analytics["channel"]["id"] == 1
+    period = analytics["period"]
+
+    # Подписчики
+    assert period["members_total_growth"] == members[-1].members_count - members[0].members_count
+    assert period["growth_days"] == len(members)
+
+    # Агрегаты просмотров берутся из views_history
+    assert period["total_views"] == sum(v.total_views for v in views)
+    assert period["total_posts"] == sum(v.posts_count for v in views)
+    assert period["avg_views_per_post"] == period["total_views"] / period["total_posts"]
+
+    # ER-метрики
+    assert period["err"] == pytest.approx(period["engagement_rate"])
+    assert period["er_classic"] == pytest.approx(
+        (period["total_reactions"] + period["total_forwards"]) / channel.subscribers_count * 100
+    )
+    assert period["vtr"] == pytest.approx(
+        period["avg_views_per_post"] / channel.subscribers_count * 100
+    )
+    assert 0 < period["avg_post_er"] < 100
+
+    # Лучшее время публикации — 19:00 даёт максимум среднего охвата
+    assert period["best_posting_hour"] == 19
+    assert period["best_posting_weekday"] in {0, 1, 2}
+
+    # Контент-микс собран
+    assert set(analytics["content_breakdown"].keys()) == {"text", "photo"}
+    assert analytics["content_breakdown"]["photo"]["posts_count"] == 2
+
+    # Топ постов отсортирован по охвату
+    top_views = [post["views"] for post in analytics["top_posts"]]
+    assert top_views == sorted(top_views, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_channel_analytics_returns_empty_for_unknown_channel() -> None:
+    session = _FakeSession(channel=None, members=[], views=[], posts=[])
+    service = _build_service_with_session(session)
+
+    result = await service.get_channel_analytics(channel_id=42, days=7)
+
+    assert result == {}


### PR DESCRIPTION
- DatabaseService.get_channel_analytics: ER classic, ERR, VTR/Reach Rate, средний ER поста, лучший день недели, posts_by_hour/posts_by_weekday, avg_posts_per_day, current_subscribers
- src/handlers/analytics_charts.py: рендер PNG-дашборда канала и сравнительного графика роста (matplotlib Agg, headless)
- /stats: расширенный вывод (ER classic/ERR/VTR/средний ER поста, лучший час и день недели, авто-рекомендации)
- /summary: ER, топ по ERR, топ по росту + кнопки графиков
- /chart, /growth_chart: отправка картинок (BufferedInputFile, asyncio.to_thread, без записи на диск)
- callback chart_/growth_chart/summary_chart
- requirements: pytest-asyncio, pytest-cov
- tests: smoke-тесты графиков и расчета аналитики (7 тестов, все зеленые)